### PR TITLE
Changed request from HEAD to GET in the API check loop

### DIFF
--- a/run-dat-platform.sh
+++ b/run-dat-platform.sh
@@ -69,7 +69,7 @@ API_URL="http://localhost:8000/connections/list"
 
 while true; do
     # Use curl to check if the API is reachable
-    if curl --output /dev/null -H 'accept: application/json' --silent --head --fail "$API_URL"; then
+    if curl -X 'GET' --output /dev/null -H 'accept: application/json' --silent --head --fail "$API_URL"; then
         echo "API is reachable. Exiting the loop."
         break
     else


### PR DESCRIPTION
The request that we are making to the API to check if it is reachable was returning a 405 response

 because the request endpoint does not receive HEAD requests.

I have changed the HEAD request to GET and tested it. It works.