### PR TITLE
Bugfix/actors.csv not found bug

### DIFF
--- a/run-dat-platform.sh
+++ b/run-dat-platform.sh
@@ -83,6 +83,7 @@ mkdir sh-scripts
 
 # Step 7.2: Download an sh file via curl and save it in sh-scripts directory
 curl -o sh-scripts/actors-seed.sh https://raw.githubusercontent.com/dat-labs/dat-main/main/sh-scripts/actors-seed.sh
+curl -o sh-scripts/actors.csv https://raw.githubusercontent.com/dat-labs/dat-main/main/sh-scripts/actors.csv
 
 # Step 7.3: Execute the downloaded file
 bash sh-scripts/actors-seed.sh

--- a/run-dat-platform.sh
+++ b/run-dat-platform.sh
@@ -83,7 +83,6 @@ mkdir sh-scripts
 
 # Step 7.2: Download an sh file via curl and save it in sh-scripts directory
 curl -o sh-scripts/actors-seed.sh https://raw.githubusercontent.com/dat-labs/dat-main/main/sh-scripts/actors-seed.sh
-curl -o sh-scripts/actors.csv https://raw.githubusercontent.com/dat-labs/dat-main/main/sh-scripts/actors.csv
 
 # Step 7.3: Execute the downloaded file
 bash sh-scripts/actors-seed.sh

--- a/sh-scripts/actors-seed.sh
+++ b/sh-scripts/actors-seed.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# Download the actors.csv file
+curl -o sh-scripts/actors.csv https://raw.githubusercontent.com/dat-labs/dat-main/main/sh-scripts/actors.csv
+
 # Read all the rows starting from the second row
 tail -n +2 sh-scripts/actors.csv |
 while IFS=, read -r name module_name icon actor_type status; # Reading each column

--- a/sh-scripts/actors.csv
+++ b/sh-scripts/actors.csv
@@ -3,6 +3,7 @@ GoogleDrive,google_drive,google_drive,source,active
 AmazonS3,amazon_s3,amazon_s3,source,active
 WebsiteCrawler,website_crawler,website_crawler,source,active
 OpenAI,openai,openai,generator,active
+Cohere,cohere,cohere,generator,active
 Pinecone,pinecone,pinecone,destination,active
 Qdrant,qdrant,qdrant,destination,active
 Weaviate,weaviate,weaviate,destination,active

--- a/update-dat-platform.sh
+++ b/update-dat-platform.sh
@@ -37,7 +37,6 @@ done
 
 # Step 6.1: Download an sh file via curl and save it in sh-scripts directory
 curl -o sh-scripts/actors-seed.sh https://raw.githubusercontent.com/dat-labs/dat-main/main/sh-scripts/actors-seed.sh
-curl -o sh-scripts/actors.csv https://raw.githubusercontent.com/dat-labs/dat-main/main/sh-scripts/actors.csv
 
 
 # Step 6.2 Execute the downloaded file


### PR DESCRIPTION
Instead of downloading actors.csv from the `run-dat-platform.sh` `update-dat-platform.sh` or `dev-dat-platform.sh` scripts, it is better to download the actors.csv file from the `actors-seed.sh` script itself